### PR TITLE
[Heading] Ajuste na renderização do componente Heading

### DIFF
--- a/src/components/Typography/Heading.jsx
+++ b/src/components/Typography/Heading.jsx
@@ -20,7 +20,7 @@ const Heading = ({ variant, fontSize, lineHeight, ...props }) => {
     }
   }, [variant])
 
-  return <Typography {...fontProps} {...props} />
+  return <Typography {...fontProps} as={variant} {...props} />
 }
 
 Heading.defaultProps = {


### PR DESCRIPTION
O componente não estava renderizando a tag correta pois o parâmetro que define qual tag deve ser renderizada não estava sendo transmitido