### PR TITLE
[Breakpoints] Remoção do primeiro breakpoint

### DIFF
--- a/src/theme/breakpoints.js
+++ b/src/theme/breakpoints.js
@@ -1,1 +1,1 @@
-export default ['360px', '768px', '1280px']
+export default ['768px', '1280px']


### PR DESCRIPTION
Esse ajuste foi sugerido pelo @gcdpinho pois o styled-system trata o início do array de breakpoints como 0, então a primeira quebra é de 0 até o próximo breakpoint (que idealmente seria 768px). A remoção do breakpoint de 480px é justamente para evitar que precise passar mais um valor ao adicionar as `width`s dos elementos.

Ex:
```
w={[1, 1, 1, 1/4]} //isso adiciona a grid de 1/4 para a grid acima de 1280px
```

após o PR, o mesmo exemplo seria
```
w={[1, 1, 1/4]} //isso adiciona a grid de 1/4 para a grid acima de 1280px
```