### PR TITLE
feat(accordion): subtitle, colorheader and colorContent

### DIFF
--- a/src/components/Accordion/Accordion.jsx
+++ b/src/components/Accordion/Accordion.jsx
@@ -40,9 +40,11 @@ const AccordionHeader = ({ expanded, expandIcon, setExpanded, title, subtitle, h
         <Typography as='span' fontWeight={1} color='gray.800' fontSize={3} lineHeight={3}>
           {title}
         </Typography>
-        <Subtitle ml={5} color='gray.500'>
-          {subtitle}
-        </Subtitle>
+        {subtitle && (
+          <Subtitle ml={5} color='gray.500'>
+            {subtitle}
+          </Subtitle>
+        )}
       </Flex>
       <StyledIcon expanded={expanded} icon={expandIcon} color='gray.800' />
     </StyledHeader>
@@ -59,18 +61,23 @@ AccordionHeader.propTypes = {
 }
 
 AccordionHeader.defaultProps = {
-  expandIcon: 'expand_more'
+  expandIcon: 'expand_more',
+  headerColor: 'white'
 }
 
-const AccordionDetail = ({ children, expanded, contentColor }) => (
-  <AccordionContent expanded={expanded} contentColor={contentColor}>
+const AccordionDetail = ({ children, expanded, detailColor }) => (
+  <AccordionContent expanded={expanded} detailColor={detailColor}>
     {children}
   </AccordionContent>
 )
 
 AccordionDetail.propTypes = {
   expanded: PropTypes.number,
-  contentColor: PropTypes.string
+  detailColor: PropTypes.string
+}
+
+AccordionDetail.defaultProps = {
+  detailColor: 'gray.100'
 }
 
 const AccordionsWrapper = styled.div(
@@ -169,12 +176,12 @@ const StyledHeader = styled(Flex)(
 )
 
 const AccordionContent = styled.div(
-  ({ expanded, contentColor }) => css`
+  ({ expanded, detailColor }) => css`
     width: inherit;
     transition: all 0.3s linear;
     box-sizing: border-box;
     overflow: hidden;
-    background-color: ${contentColor};
+    background-color: ${detailColor};
     color: gray.800;
     border-color: gray.300;
 

--- a/src/components/Accordion/Accordion.jsx
+++ b/src/components/Accordion/Accordion.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 import React, { cloneElement, Children, useState } from 'react'
 import styled, { css, layout } from '@xstyled/styled-components'
 
-import { Flex, Icon, Typography } from '../'
+import { Flex, Icon, Typography, Subtitle } from '../'
 
 const Accordion = ({ children, expanded: propsExpanded }) => {
   const [expanded, setExpanded] = useState(propsExpanded)
@@ -26,18 +26,24 @@ Accordion.defaultProps = {
   expanded: false
 }
 
-const AccordionHeader = ({ expanded, expandIcon, setExpanded, title }) => {
+const AccordionHeader = ({ expanded, expandIcon, setExpanded, title, subtitle, headerColor }) => {
   return (
     <StyledHeader
       display='flex'
       alignItems='center'
       justifyContent='space-between'
+      bg={headerColor}
       expanded={expanded}
       onClick={() => setExpanded(current => !current)}
     >
-      <Typography as='span' fontWeight={1} color='gray.800' fontSize={3} lineHeight={3}>
-        {title}
-      </Typography>
+      <Flex>
+        <Typography as='span' fontWeight={1} color='gray.800' fontSize={3} lineHeight={3}>
+          {title}
+        </Typography>
+        <Subtitle ml={5} color='gray.500'>
+          {subtitle}
+        </Subtitle>
+      </Flex>
       <StyledIcon expanded={expanded} icon={expandIcon} color='gray.800' />
     </StyledHeader>
   )
@@ -47,17 +53,24 @@ AccordionHeader.propTypes = {
   expanded: PropTypes.number,
   expandIcon: PropTypes.string,
   setExpanded: PropTypes.func,
-  title: PropTypes.string.isRequired
+  title: PropTypes.string.isRequired,
+  subtitle: PropTypes.string,
+  headerColor: PropTypes.string
 }
 
 AccordionHeader.defaultProps = {
   expandIcon: 'expand_more'
 }
 
-const AccordionDetail = ({ children, expanded }) => <AccordionContent expanded={expanded}>{children}</AccordionContent>
+const AccordionDetail = ({ children, expanded, contentColor }) => (
+  <AccordionContent expanded={expanded} contentColor={contentColor}>
+    {children}
+  </AccordionContent>
+)
 
 AccordionDetail.propTypes = {
-  expanded: PropTypes.number
+  expanded: PropTypes.number,
+  contentColor: PropTypes.string
 }
 
 const AccordionsWrapper = styled.div(
@@ -139,7 +152,6 @@ const StyledIcon = styled(Icon)(
 const StyledHeader = styled(Flex)(
   ({ expanded }) => css`
     padding: 4;
-    background: white;
     height: 56px;
     width: inherit;
     cursor: pointer;
@@ -157,12 +169,12 @@ const StyledHeader = styled(Flex)(
 )
 
 const AccordionContent = styled.div(
-  ({ expanded }) => css`
+  ({ expanded, contentColor }) => css`
     width: inherit;
     transition: all 0.3s linear;
     box-sizing: border-box;
     overflow: hidden;
-    background-color: gray.100;
+    background-color: ${contentColor};
     color: gray.800;
     border-color: gray.300;
 

--- a/src/stories/Accordion.stories.mdx
+++ b/src/stories/Accordion.stories.mdx
@@ -21,8 +21,8 @@ O componente `Accordion` permite que uma área seja encolhida e/ou expandida. De
     <ThemeProvider>
       <AccordionsWrapper>
         <Accordion>
-          <AccordionHeader title='Lorem Ipsum' />
-          <AccordionDetail>
+          <AccordionHeader title='Lorem Ipsum' subtitle='Lorem Ipsum' />
+          <AccordionDetail contentColor='#F5F5F5'>
             <Typography>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed ligula at lorem pretium pulvinar sodales
               sed eros. Donec a risus a mauris pretium scelerisque.
@@ -52,7 +52,7 @@ O componente `Accordion` permite que uma área seja encolhida e/ou expandida. De
       <AccordionsWrapper>
         <Accordion>
           <AccordionHeader title='Lorem Ipsum' />
-          <AccordionDetail>
+          <AccordionDetail contentColor='#F5F5F5'>
             <Typography>
               Lorem Ipsum dolot sit amet, consectetur adipiscing elit. Duis sed ligula at lorem pretium pulvinar sodales
               sed eros. Donec a risus a mauris pretium scelerisque.
@@ -91,7 +91,7 @@ O componente `Accordion` permite que uma área seja encolhida e/ou expandida. De
       <AccordionsWrapper>
         <Accordion>
           <AccordionHeader title='Lorem Ipsum' />
-          <AccordionDetail>
+          <AccordionDetail contentColor='#F5F5F5'>
             <Typography>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed ligula at lorem pretium pulvinar sodales
               sed eros. Donec a risus a mauris pretium scelerisque.
@@ -100,7 +100,7 @@ O componente `Accordion` permite que uma área seja encolhida e/ou expandida. De
         </Accordion>
         <Accordion>
           <AccordionHeader title='Lorem Ipsum' />
-          <AccordionDetail>
+          <AccordionDetail contentColor='#F5F5F5'>
             <Typography>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed ligula at lorem pretium pulvinar sodales
               sed eros. Donec a risus a mauris pretium scelerisque.
@@ -109,7 +109,7 @@ O componente `Accordion` permite que uma área seja encolhida e/ou expandida. De
         </Accordion>
         <Accordion>
           <AccordionHeader title='Lorem Ipsum' />
-          <AccordionDetail>
+          <AccordionDetail contentColor='#F5F5F5'>
             <Typography>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed ligula at lorem pretium pulvinar sodales
               sed eros. Donec a risus a mauris pretium scelerisque.
@@ -120,7 +120,7 @@ O componente `Accordion` permite que uma área seja encolhida e/ou expandida. De
       <AccordionsWrapper border='line'>
         <Accordion>
           <AccordionHeader title='Lorem Ipsum' />
-          <AccordionDetail>
+          <AccordionDetail contentColor='#F5F5F5'>
             <Typography>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed ligula at lorem pretium pulvinar sodales
               sed eros. Donec a risus a mauris pretium scelerisque.
@@ -129,7 +129,7 @@ O componente `Accordion` permite que uma área seja encolhida e/ou expandida. De
         </Accordion>
         <Accordion>
           <AccordionHeader title='Lorem Ipsum' />
-          <AccordionDetail>
+          <AccordionDetail contentColor='#F5F5F5'>
             <Typography>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed ligula at lorem pretium pulvinar sodales
               sed eros. Donec a risus a mauris pretium scelerisque.
@@ -138,7 +138,7 @@ O componente `Accordion` permite que uma área seja encolhida e/ou expandida. De
         </Accordion>
         <Accordion>
           <AccordionHeader title='Lorem Ipsum' />
-          <AccordionDetail>
+          <AccordionDetail contentColor='#F5F5F5'>
             <Typography>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed ligula at lorem pretium pulvinar sodales
               sed eros. Donec a risus a mauris pretium scelerisque.

--- a/src/stories/Accordion.stories.mdx
+++ b/src/stories/Accordion.stories.mdx
@@ -22,7 +22,7 @@ O componente `Accordion` permite que uma área seja encolhida e/ou expandida. De
       <AccordionsWrapper>
         <Accordion>
           <AccordionHeader title='Lorem Ipsum' />
-          <AccordionDetail contentColor='#F5F5F5'>
+          <AccordionDetail >
             <Typography>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed ligula at lorem pretium pulvinar sodales
               sed eros. Donec a risus a mauris pretium scelerisque.
@@ -35,6 +35,8 @@ O componente `Accordion` permite que uma área seja encolhida e/ou expandida. De
 </Canvas>
 
 # Subtitle
+
+É possível passar um subtitle para `Accordion` enviando uma string através da propriedade `subtitle`.
 
 <Canvas>
   <Story
@@ -51,6 +53,36 @@ O componente `Accordion` permite que uma área seja encolhida e/ou expandida. De
         <Accordion>
           <AccordionHeader title='Lorem Ipsum' subtitle='Lorem Ipsum' />
           <AccordionDetail>
+            <Typography>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed ligula at lorem pretium pulvinar sodales
+              sed eros. Donec a risus a mauris pretium scelerisque.
+            </Typography>
+          </AccordionDetail>
+        </Accordion>
+      </AccordionsWrapper>
+    </ThemeProvider>
+  </Story>
+</Canvas>
+
+# Color
+
+É possível definir cores para o Header e o Content do `Accordion` atavés das propriedades `headerColor` e `detailColor`.
+
+<Canvas>
+  <Story
+    name='Color'
+    parameters={{
+      design: {
+        type: 'figma',
+        url: 'https://www.figma.com/file/O3bKxIcsj2rc1FNIRclJyT/Saturn-System?node-id=560%3A0'
+      }
+    }}
+  >
+    <ThemeProvider>
+      <AccordionsWrapper>
+        <Accordion>
+          <AccordionHeader title='Lorem Ipsum' headerColor='gray.100' />
+          <AccordionDetail detailColor='white' >
             <Typography>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed ligula at lorem pretium pulvinar sodales
               sed eros. Donec a risus a mauris pretium scelerisque.

--- a/src/stories/Accordion.stories.mdx
+++ b/src/stories/Accordion.stories.mdx
@@ -22,7 +22,7 @@ O componente `Accordion` permite que uma área seja encolhida e/ou expandida. De
       <AccordionsWrapper>
         <Accordion>
           <AccordionHeader title='Lorem Ipsum' subtitle='Lorem Ipsum' />
-          <AccordionDetail contentColor='#F5F5F5'>
+          <AccordionDetail>
             <Typography>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed ligula at lorem pretium pulvinar sodales
               sed eros. Donec a risus a mauris pretium scelerisque.
@@ -52,7 +52,7 @@ O componente `Accordion` permite que uma área seja encolhida e/ou expandida. De
       <AccordionsWrapper>
         <Accordion>
           <AccordionHeader title='Lorem Ipsum' />
-          <AccordionDetail contentColor='#F5F5F5'>
+          <AccordionDetail>
             <Typography>
               Lorem Ipsum dolot sit amet, consectetur adipiscing elit. Duis sed ligula at lorem pretium pulvinar sodales
               sed eros. Donec a risus a mauris pretium scelerisque.
@@ -91,7 +91,7 @@ O componente `Accordion` permite que uma área seja encolhida e/ou expandida. De
       <AccordionsWrapper>
         <Accordion>
           <AccordionHeader title='Lorem Ipsum' />
-          <AccordionDetail contentColor='#F5F5F5'>
+          <AccordionDetail>
             <Typography>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed ligula at lorem pretium pulvinar sodales
               sed eros. Donec a risus a mauris pretium scelerisque.
@@ -100,7 +100,7 @@ O componente `Accordion` permite que uma área seja encolhida e/ou expandida. De
         </Accordion>
         <Accordion>
           <AccordionHeader title='Lorem Ipsum' />
-          <AccordionDetail contentColor='#F5F5F5'>
+          <AccordionDetail>
             <Typography>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed ligula at lorem pretium pulvinar sodales
               sed eros. Donec a risus a mauris pretium scelerisque.
@@ -109,7 +109,7 @@ O componente `Accordion` permite que uma área seja encolhida e/ou expandida. De
         </Accordion>
         <Accordion>
           <AccordionHeader title='Lorem Ipsum' />
-          <AccordionDetail contentColor='#F5F5F5'>
+          <AccordionDetail>
             <Typography>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed ligula at lorem pretium pulvinar sodales
               sed eros. Donec a risus a mauris pretium scelerisque.
@@ -120,7 +120,7 @@ O componente `Accordion` permite que uma área seja encolhida e/ou expandida. De
       <AccordionsWrapper border='line'>
         <Accordion>
           <AccordionHeader title='Lorem Ipsum' />
-          <AccordionDetail contentColor='#F5F5F5'>
+          <AccordionDetail>
             <Typography>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed ligula at lorem pretium pulvinar sodales
               sed eros. Donec a risus a mauris pretium scelerisque.
@@ -129,7 +129,7 @@ O componente `Accordion` permite que uma área seja encolhida e/ou expandida. De
         </Accordion>
         <Accordion>
           <AccordionHeader title='Lorem Ipsum' />
-          <AccordionDetail contentColor='#F5F5F5'>
+          <AccordionDetail>
             <Typography>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed ligula at lorem pretium pulvinar sodales
               sed eros. Donec a risus a mauris pretium scelerisque.
@@ -138,7 +138,7 @@ O componente `Accordion` permite que uma área seja encolhida e/ou expandida. De
         </Accordion>
         <Accordion>
           <AccordionHeader title='Lorem Ipsum' />
-          <AccordionDetail contentColor='#F5F5F5'>
+          <AccordionDetail>
             <Typography>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed ligula at lorem pretium pulvinar sodales
               sed eros. Donec a risus a mauris pretium scelerisque.

--- a/src/stories/Accordion.stories.mdx
+++ b/src/stories/Accordion.stories.mdx
@@ -21,6 +21,34 @@ O componente `Accordion` permite que uma área seja encolhida e/ou expandida. De
     <ThemeProvider>
       <AccordionsWrapper>
         <Accordion>
+          <AccordionHeader title='Lorem Ipsum' />
+          <AccordionDetail contentColor='#F5F5F5'>
+            <Typography>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed ligula at lorem pretium pulvinar sodales
+              sed eros. Donec a risus a mauris pretium scelerisque.
+            </Typography>
+          </AccordionDetail>
+        </Accordion>
+      </AccordionsWrapper>
+    </ThemeProvider>
+  </Story>
+</Canvas>
+
+# Subtitle
+
+<Canvas>
+  <Story
+    name='Subtitle'
+    parameters={{
+      design: {
+        type: 'figma',
+        url: 'https://www.figma.com/file/O3bKxIcsj2rc1FNIRclJyT/Saturn-System?node-id=560%3A0'
+      }
+    }}
+  >
+    <ThemeProvider>
+      <AccordionsWrapper>
+        <Accordion>
           <AccordionHeader title='Lorem Ipsum' subtitle='Lorem Ipsum' />
           <AccordionDetail>
             <Typography>


### PR DESCRIPTION
## Descreva o que foi feito neste PR (Obrigatório)
Adiciona subtitle no header, além de background-color para o Header e Content.

## Como testar
- Subtítulo: propriedade **subtitle** do AccordionHeader
- Background Header: propriedade **headerColor** do AccordionHeader
- Background Content: propriedade **contentColor** do AccordionDetail

## Garanto que os seguintes aspectos foram verificados
- [x] Adicionar PropTypes no component (página/rota não é necessário)
- [x] Cuidar padrão de imports
- [x] Foi testado em todas as resoluções

