### PR TITLE
feat(header-height-accordion): add custom height to accordion header

### DIFF
--- a/src/components/Accordion/Accordion.jsx
+++ b/src/components/Accordion/Accordion.jsx
@@ -26,13 +26,14 @@ Accordion.defaultProps = {
   expanded: false
 }
 
-const AccordionHeader = ({ expanded, expandIcon, setExpanded, title, subtitle, headerColor }) => {
+const AccordionHeader = ({ expanded, expandIcon, setExpanded, title, subtitle, headerColor, headerHeight }) => {
   return (
     <StyledHeader
       display='flex'
       alignItems='center'
       justifyContent='space-between'
       bg={headerColor}
+      headerHeight={headerHeight}
       expanded={expanded}
       onClick={() => setExpanded(current => !current)}
     >
@@ -57,12 +58,14 @@ AccordionHeader.propTypes = {
   setExpanded: PropTypes.func,
   title: PropTypes.string.isRequired,
   subtitle: PropTypes.string,
-  headerColor: PropTypes.string
+  headerColor: PropTypes.string,
+  headerHeight: PropTypes.string
 }
 
 AccordionHeader.defaultProps = {
   expandIcon: 'expand_more',
-  headerColor: 'white'
+  headerColor: 'white',
+  headerHeight: '56px'
 }
 
 const AccordionDetail = ({ children, expanded, detailColor }) => (
@@ -158,9 +161,9 @@ const StyledIcon = styled(Icon)(
 )
 
 const StyledHeader = styled(Flex)(
-  ({ expanded }) => css`
+  ({ headerHeight, expanded }) => css`
     padding: 4;
-    height: 56px;
+    height: ${headerHeight};
     width: inherit;
     cursor: pointer;
     box-sizing: border-box;

--- a/src/stories/Accordion.stories.mdx
+++ b/src/stories/Accordion.stories.mdx
@@ -22,7 +22,7 @@ O componente `Accordion` permite que uma área seja encolhida e/ou expandida. De
       <AccordionsWrapper>
         <Accordion>
           <AccordionHeader title='Lorem Ipsum' />
-          <AccordionDetail >
+          <AccordionDetail>
             <Typography>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed ligula at lorem pretium pulvinar sodales
               sed eros. Donec a risus a mauris pretium scelerisque.
@@ -82,7 +82,7 @@ O componente `Accordion` permite que uma área seja encolhida e/ou expandida. De
       <AccordionsWrapper>
         <Accordion>
           <AccordionHeader title='Lorem Ipsum' headerColor='gray.100' />
-          <AccordionDetail detailColor='white' >
+          <AccordionDetail detailColor='white'>
             <Typography>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed ligula at lorem pretium pulvinar sodales
               sed eros. Donec a risus a mauris pretium scelerisque.
@@ -198,6 +198,36 @@ O componente `Accordion` permite que uma área seja encolhida e/ou expandida. De
         </Accordion>
         <Accordion>
           <AccordionHeader title='Lorem Ipsum' />
+          <AccordionDetail>
+            <Typography>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed ligula at lorem pretium pulvinar sodales
+              sed eros. Donec a risus a mauris pretium scelerisque.
+            </Typography>
+          </AccordionDetail>
+        </Accordion>
+      </AccordionsWrapper>
+    </ThemeProvider>
+  </Story>
+</Canvas>
+
+# Header Height
+
+É possível alterar o height do `AccordionHeader` através da prop `headerHeight`.
+
+<Canvas>
+  <Story
+    name='Header Height'
+    parameters={{
+      design: {
+        type: 'figma',
+        url: 'https://www.figma.com/file/O3bKxIcsj2rc1FNIRclJyT/Saturn-System?node-id=560%3A0'
+      }
+    }}
+  >
+    <ThemeProvider>
+      <AccordionsWrapper>
+        <Accordion>
+          <AccordionHeader title='Lorem Ipsum' headerHeight='48px' />
           <AccordionDetail>
             <Typography>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sed ligula at lorem pretium pulvinar sodales


### PR DESCRIPTION
O que foi feito?
novamente por demanda interna, foi necessário uma nova feature que permitisse ter um height customizando no Accordion Header. Para isso basta passar a prop 'headerHeight'. A implementação basicamente se dá por uma prop que será aplicada no AccordionHeader.