### PR TITLE
fix(text-field-label-color): add fix

### DIFF
--- a/src/components/TextField/TextField.jsx
+++ b/src/components/TextField/TextField.jsx
@@ -68,8 +68,8 @@ const disabledVariant = variant({
   default: false,
   variants: {
     true: css`
-      p {
-        color: disabled;
+      * {
+        color: disabled !important;
       }
       div {
         border-color: gray.400;

--- a/src/stories/TextField.stories.mdx
+++ b/src/stories/TextField.stories.mdx
@@ -13,7 +13,7 @@ export const TextFieldControls = args => (
 
 # TextField
 
-O componente de `TextField` é utilizado para que o usuário possa inserir informações na aplicação. Sua estrutura é composta por um Label (definido pela prop `label`), um campo de entrada de dados (que utiliza as props `name` e `placeholder`) e uma mensagem de auxílio (definida pela prop `message`).
+O componente de `TextField` é utilizado para que o usuário possa inserir informações na aplicação. Sua estrutura é composta por um Label (definido pela prop `label`, que recebe children), um campo de entrada de dados (que utiliza as props `name` e `placeholder`) e uma mensagem de auxílio (definida pela prop `message`).
 
 <Story
   name='Base'


### PR DESCRIPTION
O que foi feito?
Foi reforçado na doc que o valor passado para a prop `label` é um children e também foi feito um fix na variant disabled que agora está obrigando que todo elemento dentro do wrapper do text field vai ficar com a cor de disabled. A tag `!important` foi adicionada porque por exemplo, sem ela, quando eu passo children com estilo próprio pode ocorrer de todo o TextField ficar com a cor disabled e aquele elemento em específico não ficar.

```javascript
label={
<p>
Lorem <span style={{ color: 'green' }}>Ipsum</span>
</p>
}
```