### PR TITLE
feat(text-field-width-styled): add layout, space and width 100%

### DIFF
--- a/src/components/TextField/TextField.jsx
+++ b/src/components/TextField/TextField.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import React, { useState, forwardRef } from 'react'
 import styled, { css } from '@xstyled/styled-components'
-import { borders, variant } from '@xstyled/system'
+import { borders, layout, space, variant } from '@xstyled/system'
 
 import { Flex, Box } from '../Grid'
 import { Caption, Typography } from '..'
@@ -99,7 +99,9 @@ const focusVariant = variant({
 const Wrapper = styled(Box)`
   ${errorVariant}
   ${disabledVariant}
-  width: fit-content;
+  width: 100%;
+  ${layout}
+  ${space}
 `
 const Label = styled(Typography)`
   font-size: 2;


### PR DESCRIPTION
O que foi feito?
Adicionado as props de `layout` e `space` do xstyled. Mudado a width do container do Text Field de fit-content para 100%