### PR TITLE
fix(function-on-select): remove required onOptionSelected function

### DIFF
--- a/src/components/Select/Select.jsx
+++ b/src/components/Select/Select.jsx
@@ -32,7 +32,7 @@ const Select = forwardRef(
     const handleChange = option => {
       setOptionSelected(option)
       setIsOpened(false)
-      onOptionSelected(option)
+      onOptionSelected && onOptionSelected(option)
     }
 
     useClickOutside(() => isOpened && setIsOpened(false), containerRef)


### PR DESCRIPTION
---
name: Remover obrigatoriedade de passar a prop onOptionSelect
about: Resolução de algum bug presente no projeto
---

**Descrição do Bug**
ao usar este componente, é obrigatório passar a prop onOptionSelect. Em  alguns casos tivemos de passar uma função vazia para que o componente funcionasse

**Comportamento Esperado**
Agora esta prop é opcional

**Links Relacionados**
JIRA:
https://naveteam.atlassian.net/browse/RIV-369