### PR TITLE
feat(clear-select): add function

### DIFF
--- a/src/components/Iconography/Icon.jsx
+++ b/src/components/Iconography/Icon.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from '@xstyled/styled-components'
-import { color, th, space, layout } from '@xstyled/system'
+import { borders, color, th, space, layout } from '@xstyled/system'
 import PropTypes from 'prop-types'
 
 import * as Icons from '../../icons'
@@ -15,6 +15,7 @@ const Icon = styled(IconComponent)`
   * {
     fill: ${({ color }) => th.color(color)};
   }
+  ${borders}
   ${color}
   ${space}
   ${layout}

--- a/src/components/Select/Select.jsx
+++ b/src/components/Select/Select.jsx
@@ -11,6 +11,7 @@ const Select = forwardRef(
   (
     {
       clearValue,
+      onClearSelect,
       name,
       label,
       options,
@@ -40,6 +41,7 @@ const Select = forwardRef(
 
     const clearValueFunction = e => {
       e.stopPropagation()
+      onClearSelect && onClearSelect()
       setOptionSelected({})
     }
 
@@ -93,7 +95,7 @@ const Select = forwardRef(
               ))}
             </SelectBase>
             <Flex justifyContent='center' alignItems='center'>
-              {clearValue && Object.keys(optionSelected).length > 0 && (
+              {clearValue && optionSelected[optionValue] && (
                 <Icon
                   icon='times'
                   pr='12px'
@@ -289,6 +291,7 @@ const OverflowText = styled(Typography)`
 `
 
 Select.defaultProps = {
+  clearValue: true,
   error: false,
   disabled: false,
   quiet: false,
@@ -301,6 +304,7 @@ Select.defaultProps = {
 
 Select.propTypes = {
   clearValue: PropTypes.bool,
+  onClearSelect: PropTypes.func,
   label: PropTypes.string,
   placeholder: PropTypes.string,
   options: PropTypes.arrayOf(PropTypes.object),

--- a/src/components/Select/Select.jsx
+++ b/src/components/Select/Select.jsx
@@ -10,6 +10,7 @@ import { Typography, Caption, Icon } from '..'
 const Select = forwardRef(
   (
     {
+      clearValue,
       name,
       label,
       options,
@@ -35,6 +36,11 @@ const Select = forwardRef(
       setOptionSelected(option)
       setIsOpened(false)
       onOptionSelected && onOptionSelected(option, shouldValidation)
+    }
+
+    const clearValueFunction = e => {
+      e.stopPropagation()
+      setOptionSelected({})
     }
 
     useEffect(() => {
@@ -86,7 +92,22 @@ const Select = forwardRef(
                 </option>
               ))}
             </SelectBase>
-            <Icon icon={!disabled && isOpened ? 'ExpandLess' : 'ExpandMore'} color='gray.800' />
+            <Flex justifyContent='center' alignItems='center'>
+              {clearValue && Object.keys(optionSelected).length > 0 && (
+                <Icon
+                  icon='times'
+                  pr='12px'
+                  borderRight='1px solid'
+                  borderColor='gray.500'
+                  marginRight='3'
+                  width='16px'
+                  height='16px'
+                  color='gray.800'
+                  onClick={clearValueFunction}
+                />
+              )}
+              <Icon icon={!disabled && isOpened ? 'ExpandLess' : 'ExpandMore'} color='gray.800' />
+            </Flex>
           </SelectContainer>
 
           {isOpened && (
@@ -177,7 +198,7 @@ const Wrapper = styled(Box)(
     ${SelectContainer} {
       background: ${bg || backgroundColor};
     }
-`
+  `
 )
 
 const Message = styled(Caption)(
@@ -279,6 +300,7 @@ Select.defaultProps = {
 }
 
 Select.propTypes = {
+  clearValue: PropTypes.bool,
   label: PropTypes.string,
   placeholder: PropTypes.string,
   options: PropTypes.arrayOf(PropTypes.object),

--- a/src/stories/Select.stories.mdx
+++ b/src/stories/Select.stories.mdx
@@ -76,4 +76,30 @@ O `Select` pode receber a prop de `disabled`, que desabilita todo o seu uso.
   </Story>
 </Canvas>
 
+# Clear Value
+
+Passando a prop `clearValue` para o `Select`, será exibido um icone no componente, ao tocar nesse icone o valor presente no `Select` será limpo.
+
+<Canvas>
+  <Story
+    name='Clear Value'
+    parameters={{
+      design: {
+        type: 'figma',
+        url: 'https://www.figma.com/file/O3bKxIcsj2rc1FNIRclJyT/Saturn-System?node-id=242%3A139'
+      }
+    }}
+  >
+    <ThemeProvider>
+      <Select
+        clearValue
+        name='clearValue'
+        label='Clear Value'
+        options={optionsSelect}
+        placeholder='Selecione uma opção'
+      />
+    </ThemeProvider>
+  </Story>
+</Canvas>
+
 <ArgsTable of={Select} />


### PR DESCRIPTION
O que foi feito?
Adiciona a funcionalidade de limpar o select. Basta passar uma prop e a função estará ativa. Para mais detalhes acesse o video que gravei explicando a implementação:

https://youtu.be/x2ONQUIVYaw
