### PR TITLE
fix(select-clear): change padding space to a Divider

### DIFF
--- a/src/components/Select/Select.jsx
+++ b/src/components/Select/Select.jsx
@@ -96,17 +96,10 @@ const Select = forwardRef(
             </SelectBase>
             <Flex justifyContent='center' alignItems='center'>
               {clearValue && optionSelected[optionValue] && (
-                <Icon
-                  icon='times'
-                  pr='12px'
-                  borderRight='1px solid'
-                  borderColor='gray.500'
-                  marginRight='3'
-                  width='16px'
-                  height='16px'
-                  color='gray.800'
-                  onClick={clearValueFunction}
-                />
+                <>
+                  <Icon icon='times' width='16px' height='16px' color='gray.800' onClick={clearValueFunction} />
+                  <Box bg='gray.500' width='1px' height='24px' margin='0 8px 0px 12px'></Box>
+                </>
               )}
               <Icon icon={!disabled && isOpened ? 'ExpandLess' : 'ExpandMore'} color='gray.800' />
             </Flex>


### PR DESCRIPTION
O que foi feito?
Recentemente foi adicionado a funcionalidade de limpar o Select, porém um Bug não foi mostrado durante o Storybook, detectado apenas quando a funcionalidade foi ser usada em um projeto. O problema é em relação ao Padding que estava sendo aplicado no icone de Times. Com o Padding aplicado o icone não era mostrado pois ele saia da sua viewbox. Para arrumar isso foi removido as margins e padding do Icon times e foi adicionado um Divider entre os icones