### PR TITLE
feat(text-field-suffix-icon): add custom affixes

### DIFF
--- a/src/components/TextField/TextField.jsx
+++ b/src/components/TextField/TextField.jsx
@@ -33,7 +33,7 @@ const TextField = forwardRef(
       <Wrapper disabled={disabled} {...props}>
         <Label>{label}</Label>
         <Container focus={focus} borderColor={borderColor}>
-          {prefix ? <Affix forwardedAs='span'>{prefix}</Affix> : customPrefix && customPrefix}
+          {prefix ? <Affix forwardedAs='span'>{prefix}</Affix> : customPrefix}
           <InputBase
             ref={ref}
             type={type}
@@ -48,7 +48,7 @@ const TextField = forwardRef(
             {...inputProps}
           />
 
-          {suffix ? <Affix forwardedAs='span'>{suffix}</Affix> : customSuffix && customSuffix}
+          {suffix ? <Affix forwardedAs='span'>{suffix}</Affix> : customSuffix}
         </Container>
         <Message>{message}</Message>
       </Wrapper>

--- a/src/components/TextField/TextField.jsx
+++ b/src/components/TextField/TextField.jsx
@@ -10,6 +10,8 @@ const TextField = forwardRef(
   (
     {
       borderColor,
+      customPrefix,
+      customSuffix,
       label,
       message,
       prefix,
@@ -31,7 +33,7 @@ const TextField = forwardRef(
       <Wrapper disabled={disabled} {...props}>
         <Label>{label}</Label>
         <Container focus={focus} borderColor={borderColor}>
-          {prefix && <Affix forwardedAs='span'>{prefix}</Affix>}
+          {prefix ? <Affix forwardedAs='span'>{prefix}</Affix> : customPrefix && customPrefix}
           <InputBase
             ref={ref}
             type={type}
@@ -45,7 +47,8 @@ const TextField = forwardRef(
             defaultValue={defaultValue}
             {...inputProps}
           />
-          {suffix && <Affix forwardedAs='span'>{suffix}</Affix>}
+
+          {suffix ? <Affix forwardedAs='span'>{suffix}</Affix> : customSuffix && customSuffix}
         </Container>
         <Message>{message}</Message>
       </Wrapper>
@@ -57,6 +60,8 @@ TextField.propTypes = {
   borderColor: PropTypes.string,
   label: PropTypes.string,
   message: PropTypes.string,
+  customPrefix: PropTypes.object,
+  customSuffix: PropTypes.object,
   prefix: PropTypes.string,
   suffix: PropTypes.string,
   placeholder: PropTypes.string,

--- a/src/stories/TextField.stories.mdx
+++ b/src/stories/TextField.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks'
 
-import { TextField } from '../components'
+import { TextField, Icon } from '../components'
 import { ThemeProvider } from '../theme'
 
 <Meta title='Data input/TextField' component={TextField} argTypes={{ error: { controls: 'boolean' } }} />
@@ -30,7 +30,7 @@ O componente de `TextField` é utilizado para que o usuário possa inserir infor
 
 # Affixes
 
-O `TextField` pode receber prefixos e sufixos para trazer um feedback para o usuário de qual é o escopo das informações inseridas.
+O `TextField` pode receber prefixos e sufixos para trazer um feedback para o usuário de qual é o escopo das informações inseridas. Também é possível utilizar affixes customizados, elementos children podem ser passados através das props `customPrefix` e `customSuffix`.
 
 <Canvas>
   <Story
@@ -44,7 +44,9 @@ O `TextField` pode receber prefixos e sufixos para trazer um feedback para o usu
   >
     <ThemeProvider>
       <TextField name='prefix' label='Prefix' placeholder='Prefix' prefix='R$' />
+      <TextField name='prefix' label='Prefix' placeholder='Custom Prefix' customPrefix={<Icon />} />
       <TextField name='suffix' label='Suffix' placeholder='Suffix' suffix='reais' />
+      <TextField name='suffix' label='Suffix' placeholder='Custom Suffix' customSuffix={<Icon />} />
     </ThemeProvider>
   </Story>
 </Canvas>


### PR DESCRIPTION
O que foi feito?
Adicionado duas props que permitem usar suffixes e prefixes customizados através de children por props. Originalmente a ideia era permitir a utilização de icones, porém encontrei a passagem de children muito mais eficaz, podemos passar qualquer coisa em qualquer variação, não se limitando a ter de lançar novas changes simplesmente para por exemplo customizar o Ícone

![Screenshot from 2020-12-07 18-29-13](https://user-images.githubusercontent.com/67487679/101407910-58cf8680-38ba-11eb-9f11-040153261142.png)
