### PR TITLE
fix(textfield): fixes the message margin top

### DIFF
--- a/src/components/TextField/TextField.jsx
+++ b/src/components/TextField/TextField.jsx
@@ -50,7 +50,7 @@ const TextField = forwardRef(
 
           {suffix ? <Affix forwardedAs='span'>{suffix}</Affix> : customSuffix}
         </Container>
-        <Message>{message}</Message>
+        {message && <Message>{message}</Message>}
       </Wrapper>
     )
   }

--- a/src/stories/TextField.stories.mdx
+++ b/src/stories/TextField.stories.mdx
@@ -44,9 +44,9 @@ O `TextField` pode receber prefixos e sufixos para trazer um feedback para o usu
   >
     <ThemeProvider>
       <TextField name='prefix' label='Prefix' placeholder='Prefix' prefix='R$' />
-      <TextField name='prefix' label='Prefix' placeholder='Custom Prefix' customPrefix={<Icon />} />
-      <TextField name='suffix' label='Suffix' placeholder='Suffix' suffix='reais' />
-      <TextField name='suffix' label='Suffix' placeholder='Custom Suffix' customSuffix={<Icon />} />
+      <TextField mt={'1%'} name='prefix' label='Prefix' placeholder='Custom Prefix' customPrefix={<Icon />} />
+      <TextField mt={'1%'} name='suffix' label='Suffix' placeholder='Suffix' suffix='reais' />
+      <TextField mt={'1%'} name='suffix' label='Suffix' placeholder='Custom Suffix' customSuffix={<Icon />} />
     </ThemeProvider>
   </Story>
 </Canvas>


### PR DESCRIPTION
```markdown
## Descreva o que foi feito neste PR
    Este PR corrige a margin top que fica em 4px até mesmo quando não existe message abaixo do input de Textfield, essa 
    margin top acaba deixando o input desalinhado dos outros inputs quando inseridos em uma linha por exemplo.
    Também aproveitei para corrigir a margem entre os campos de texto no ThemeProvider, estava tudo muito junto.
    
## Cards relacionados e links externos
    [Jira]: (https://naveteam.atlassian.net/browse/RIV-823)

## Imagens 
    ![image](https://user-images.githubusercontent.com/38573412/102806414-91cc2880-439b-11eb-886f-97c84ed88f0e.png)
    ![image](https://user-images.githubusercontent.com/38573412/102806448-a3153500-439b-11eb-9537-2574faf2955e.png)

```