### PR TITLE
feat(tag): add props pattern

### DIFF
--- a/src/components/Tag/Tag.jsx
+++ b/src/components/Tag/Tag.jsx
@@ -1,36 +1,56 @@
-import React, { useState, useEffect } from 'react'
+import React, { useMemo, useCallback } from 'react'
 import styled, { css } from '@xstyled/styled-components'
 import { th, variant, compose, color, layout, space, border } from '@xstyled/system'
 import PropTypes from 'prop-types'
-import { Typography } from '../'
-import { Icon } from '../Iconography'
 
-const Tag = ({ children, close, variant, selected, ...props }) => {
-  const [tagVariant, setTagVariant] = useState('selected')
+import { Typography, Icon } from '../'
 
-  useEffect(() => {
-    if (variant) {
-      return setTagVariant(variant)
+const Tag = ({ children, close, closable, variant, selected, disabled, value, onChange, onClose, type, ...props }) => {
+  const tagVariant = useMemo(() => {
+    if (disabled || selected === 'disabled' || variant === 'disabled') {
+      return 'disabled'
     }
 
-    if (selected === 'disabled') {
-      return setTagVariant('disabled')
+    if (type === 'selectable') {
+      if (value) {
+        return 'selected'
+      } else {
+        return 'unselected'
+      }
+    }
+
+    if (variant) {
+      return variant
     }
 
     if (selected === false || selected === 'unselected') {
-      return setTagVariant('unselected')
+      return 'unselected'
     }
 
-    return setTagVariant('selected')
-  }, [variant, selected])
+    return 'selected'
+  }, [variant, selected, type, disabled, value])
+
+  const handleClick = useCallback(() => {
+    if (disabled) {
+      return
+    }
+
+    if ((closable || close) && onClose) {
+      onClose()
+    }
+
+    if (type === 'selectable' && onChange) {
+      onChange()
+    }
+  }, [type, closable, close, onClose, onChange])
 
   return (
-    <Base selected={tagVariant} {...props}>
+    <Base selected={tagVariant} onClick={handleClick} {...props}>
       <Content>
-        <Text padding={close ? '3px 0 3px 4px' : '3px 4px 3px 4px'} lineHeight={1}>
+        <Text padding={close || closable ? '3px 0 3px 4px' : '3px 4px 3px 4px'} lineHeight={1}>
           {children}
         </Text>
-        {close && <Icon icon='clear' color='white' height='16' />}
+        {(close || closable) && <Icon icon='clear' color='white' height='16' />}
       </Content>
     </Base>
   )
@@ -60,6 +80,7 @@ const selectedVariant = variant({
     disabled: css`
       background-color: disabled;
       border-color: disabled;
+      cursor: not-allowed;
       p {
         color: white;
       }
@@ -67,11 +88,12 @@ const selectedVariant = variant({
   }
 })
 
-const Base = styled.div`
+const Base = styled.button`
   display: inline-block;
   border-radius: 1;
   border-width: 1px;
   border-style: solid;
+  outline: none;
   cursor: pointer;
   ${baseProps};
   ${selectedVariant};
@@ -93,10 +115,14 @@ Tag.defaultProps = {
 }
 
 Tag.propTypes = {
-  variant: PropTypes.oneOf(['selected', 'unselected', 'disabled']),
   close: PropTypes.bool,
   color: PropTypes.string,
-  colorScheme: PropTypes.oneOf(['primary', 'secondary'])
+  colorScheme: PropTypes.string,
+  type: PropTypes.oneOf(['info', 'selectable']),
+  value: PropTypes.bool,
+  disabled: PropTypes.bool,
+  onChange: PropTypes.func,
+  onClose: PropTypes.func
 }
 
 export default Tag

--- a/src/components/Tag/Tag.jsx
+++ b/src/components/Tag/Tag.jsx
@@ -36,11 +36,11 @@ const Tag = ({ children, close, closable, variant, selected, disabled, value, on
     }
 
     if ((closable || close) && onClose) {
-      onClose()
+      return onClose()
     }
 
     if (type === 'selectable' && onChange) {
-      onChange()
+      return onChange()
     }
   }, [type, closable, close, onClose, onChange])
 

--- a/src/components/Tag/Tag.jsx
+++ b/src/components/Tag/Tag.jsx
@@ -1,20 +1,40 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import styled, { css } from '@xstyled/styled-components'
 import { th, variant, compose, color, layout, space, border } from '@xstyled/system'
 import PropTypes from 'prop-types'
 import { Typography } from '../'
 import { Icon } from '../Iconography'
 
-const Tag = ({ children, close, ...props }) => (
-  <Base {...props}>
-    <Content>
-      <Text padding={close ? '3px 0 3px 4px' : '3px 4px 3px 4px'} lineHeight={1}>
-        {children}
-      </Text>
-      {close && <Icon icon='clear' color='white' height='16' />}
-    </Content>
-  </Base>
-)
+const Tag = ({ children, close, variant, selected, ...props }) => {
+  const [tagVariant, setTagVariant] = useState('selected')
+
+  useEffect(() => {
+    if (variant) {
+      return setTagVariant(variant)
+    }
+
+    if (selected === 'disabled') {
+      return setTagVariant('disabled')
+    }
+
+    if (selected === false || selected === 'unselected') {
+      return setTagVariant('unselected')
+    }
+
+    return setTagVariant('selected')
+  }, [variant, selected])
+
+  return (
+    <Base selected={tagVariant} {...props}>
+      <Content>
+        <Text padding={close ? '3px 0 3px 4px' : '3px 4px 3px 4px'} lineHeight={1}>
+          {children}
+        </Text>
+        {close && <Icon icon='clear' color='white' height='16' />}
+      </Content>
+    </Base>
+  )
+}
 
 const baseProps = compose(color, layout, space, border)
 
@@ -23,18 +43,16 @@ const selectedVariant = variant({
   prop: 'selected',
   key: 'tag',
   variants: {
-    true: css`
-      background-color: ${({ color }) => th.color(color)};
-      border-color: ${({ color }) => th.color(color)};
-      cursor: pointer;
+    selected: css`
+      background-color: ${({ color, colorScheme }) => th.color(colorScheme || color || 'primary')};
+      border-color: ${({ color, colorScheme }) => th.color(colorScheme || color || 'primary')};
       p {
         color: white;
       }
     `,
-    false: css`
+    unselected: css`
       background-color: transparent;
       border-color: gray.600;
-      cursor: pointer;
       p {
         color: gray.600;
       }
@@ -42,7 +60,6 @@ const selectedVariant = variant({
     disabled: css`
       background-color: disabled;
       border-color: disabled;
-      cursor: default;
       p {
         color: white;
       }
@@ -55,8 +72,9 @@ const Base = styled.div`
   border-radius: 1;
   border-width: 1px;
   border-style: solid;
-  ${baseProps}
-  ${selectedVariant}
+  cursor: pointer;
+  ${baseProps};
+  ${selectedVariant};
 `
 
 const Content = styled.div`
@@ -71,15 +89,14 @@ const Text = styled(Typography)`
 `
 
 Tag.defaultProps = {
-  selected: true,
-  close: false,
-  color: 'primary'
+  close: false
 }
 
 Tag.propTypes = {
-  selected: PropTypes.oneOf([true, false, 'disabled']),
+  variant: PropTypes.oneOf(['selected', 'unselected', 'disabled']),
   close: PropTypes.bool,
-  color: PropTypes.string
+  color: PropTypes.string,
+  colorScheme: PropTypes.oneOf(['primary', 'secondary'])
 }
 
 export default Tag

--- a/src/stories/Tag.stories.mdx
+++ b/src/stories/Tag.stories.mdx
@@ -29,7 +29,7 @@ O component de `Tag` permite o usuário executar ações ou mostrar informaçõe
 
 # Color
 
-A `Tag` pode receber a prop `color`. A variant primary tem uma função de mais destaque, ideal para executar ações e/ou mostrar informações fundamentais para o usuário. A variant secondary é ideal para funções de menores destaque como informações de filtro, upload de arquivos e execuções de menor prioridade.
+A `Tag` pode receber a prop `colorScheme`. A variant primary tem uma função de mais destaque, ideal para executar ações e/ou mostrar informações fundamentais para o usuário. A variant secondary é ideal para funções de menores destaque como informações de filtro, upload de arquivos e execuções de menor prioridade.
 
 <Canvas>
   <Story
@@ -42,8 +42,8 @@ A `Tag` pode receber a prop `color`. A variant primary tem uma função de mais 
     }}
   >
     <ThemeProvider>
-      <Tag color='primary'>Primary</Tag>
-      <Tag color='secondary'>Secondary</Tag>
+      <Tag colorScheme='primary'>Primary</Tag>
+      <Tag colorScheme='secondary'>Secondary</Tag>
     </ThemeProvider>
   </Story>
 </Canvas>
@@ -68,9 +68,9 @@ A `Tag` pode receber a prop `close`. Essa prop indicará se a tag deve renderiza
   </Story>
 </Canvas>
 
-# Selected
+# Variant
 
-A prop `selected` pode definir se a `Tag` está ou não selecionada. Pode ser de grande utilidade para informar quais tags esstão sendo utilizadas ou não. A variant disabled informa se o conteúdo está indisponível para a interação com o usuário.
+A prop `variant` pode definir se a `Tag` está ou não selecionada, através dos valores selected e unselected, respectivamente. Pode ser de grande utilidade para informar quais tags estão sendo utilizadas ou não. A variant disabled informa se o conteúdo está indisponível para a interação com o usuário.
 
 <Canvas>
   <Story
@@ -83,13 +83,13 @@ A prop `selected` pode definir se a `Tag` está ou não selecionada. Pode ser de
     }}
   >
     <ThemeProvider>
-      <Tag color='primary' selected={true}>
+      <Tag colorScheme='primary' variant='selected'>
         Selected
       </Tag>
-      <Tag color='primary' selected={false}>
+      <Tag colorScheme='primary' variant='unselected'>
         Not Selected
       </Tag>
-      <Tag color='primary' selected={'disabled'}>
+      <Tag colorScheme='primary' variant='disabled'>
         Disabled
       </Tag>
     </ThemeProvider>

--- a/src/stories/Tag.stories.mdx
+++ b/src/stories/Tag.stories.mdx
@@ -1,4 +1,5 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks'
+import { useState } from 'react'
 
 import { Tag, Flex, Box } from '../components'
 import { ThemeProvider } from '../theme'
@@ -10,6 +11,22 @@ export const TagBase = args => (
     <Tag {...args}>Base Tag</Tag>
   </ThemeProvider>
 )
+
+export const ControlledTag = args => {
+  const [value, setValue] = useState(true)
+  return(
+  <ThemeProvider>
+    <Tag colorScheme='primary' type='info' {...args}>
+        Info
+      </Tag>
+      <Tag colorScheme='primary' type='selectable' value={value} onChange={() => setValue(!value)} {...args}>
+        Selectable
+      </Tag>
+      <Tag colorScheme='primary' disabled={true} {...args}>
+        Disabled
+      </Tag>
+  </ThemeProvider>
+)}
 
 # Tag
 
@@ -68,32 +85,21 @@ A `Tag` pode receber a prop `close`. Essa prop indicará se a tag deve renderiza
   </Story>
 </Canvas>
 
-# Variant
+# Type
 
-A prop `variant` pode definir se a `Tag` está ou não selecionada, através dos valores selected e unselected, respectivamente. Pode ser de grande utilidade para informar quais tags estão sendo utilizadas ou não. A variant disabled informa se o conteúdo está indisponível para a interação com o usuário.
+A prop `type` pode definir se a `Tag` serve apenas para mostrar informações ou se executa alguma ação, através dos valores info e selectable, respectivamente. Temos então as props `onChange` que informa a ação a ser executada ao mudar o estado de selecionado para não selecionado, além do `value` que é booleano que determina o estado da tag.
+A prop `disabled` informa se o conteúdo está indisponível para a interação com o usuário.
 
-<Canvas>
-  <Story
-    name='Selected'
-    parameters={{
-      design: {
-        type: 'figma',
-        url: 'https://www.figma.com/file/O3bKxIcsj2rc1FNIRclJyT/Design-System?node-id=260%3A593'
-      }
-    }}
-  >
-    <ThemeProvider>
-      <Tag colorScheme='primary' variant='selected'>
-        Selected
-      </Tag>
-      <Tag colorScheme='primary' variant='unselected'>
-        Not Selected
-      </Tag>
-      <Tag colorScheme='primary' variant='disabled'>
-        Disabled
-      </Tag>
-    </ThemeProvider>
-  </Story>
-</Canvas>
+<Story
+  name='Type'
+  parameters={{
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/O3bKxIcsj2rc1FNIRclJyT/Design-System?node-id=260%3A593'
+    }
+  }}
+>
+  {ControlledTag.bind({})}
+</Story>
 
 <ArgsTable of={Tag} />


### PR DESCRIPTION
Alterada props do componente tag para o novo padrão.

Hoje o componente de tem a prop `close` que adiciona um botão para fechar o componente, porém não dispara nenhuma ação. Também não existe alguma prop de `onClose` para disparar algum evento ao fechar.