### PR TITLE
fix(select-documentation-implementation): add new select documentation and improved documentation

### DIFF
--- a/src/components/Select/Select.jsx
+++ b/src/components/Select/Select.jsx
@@ -11,13 +11,13 @@ const Select = forwardRef(
   (
     {
       clearValue,
-      onClearSelect,
+      onClear,
       name,
       label,
       options,
       optionLabel,
       optionValue,
-      onOptionSelected,
+      onChange,
       placeholder,
       caption,
       error,
@@ -35,12 +35,12 @@ const Select = forwardRef(
     const handleChange = (option, shouldValidate = true) => {
       setOptionSelected(option)
       setIsOpened(false)
-      onOptionSelected && onOptionSelected(option, shouldValidate)
+      onChange && onChange(option, shouldValidate)
     }
 
     const clearValueFunction = e => {
       e.stopPropagation()
-      onClearSelect && onClearSelect()
+      onClear && onClear()
       setOptionSelected({})
     }
 
@@ -297,7 +297,7 @@ Select.defaultProps = {
 
 Select.propTypes = {
   clearValue: PropTypes.bool,
-  onClearSelect: PropTypes.func,
+  onClear: PropTypes.func,
   label: PropTypes.string,
   placeholder: PropTypes.string,
   options: PropTypes.arrayOf(PropTypes.object),
@@ -308,7 +308,7 @@ Select.propTypes = {
   disabled: PropTypes.bool,
   quiet: PropTypes.bool,
   name: PropTypes.string.isRequired,
-  onOptionSelected: PropTypes.func
+  onChange: PropTypes.func
 }
 
 export default Select

--- a/src/components/Select/Select.jsx
+++ b/src/components/Select/Select.jsx
@@ -23,7 +23,6 @@ const Select = forwardRef(
       error,
       disabled,
       quiet,
-      defaultValue,
       resetValue,
       ...props
     },
@@ -33,10 +32,10 @@ const Select = forwardRef(
     const [optionSelected, setOptionSelected] = useState({})
     const containerRef = useRef(null)
 
-    const handleChange = (option, shouldValidation = true) => {
+    const handleChange = (option, shouldValidate = true) => {
       setOptionSelected(option)
       setIsOpened(false)
-      onOptionSelected && onOptionSelected(option, shouldValidation)
+      onOptionSelected && onOptionSelected(option, shouldValidate)
     }
 
     const clearValueFunction = e => {
@@ -84,7 +83,8 @@ const Select = forwardRef(
             <OverflowText lineHeight={3} fontSize={3} color={!!optionSelected[optionValue] ? 'gray.900' : 'gray.500'}>
               {optionSelected[optionLabel] || placeholder}
             </OverflowText>
-            <SelectBase name={name} ref={ref} defaultValue={defaultValue}>
+
+            <SelectBase name={name} ref={ref} defaultValue={optionSelected[optionValue]}>
               <option value='' disabled>
                 {placeholder}
               </option>
@@ -308,8 +308,7 @@ Select.propTypes = {
   disabled: PropTypes.bool,
   quiet: PropTypes.bool,
   name: PropTypes.string.isRequired,
-  onOptionSelected: PropTypes.func,
-  defaultValue: PropTypes.string
+  onOptionSelected: PropTypes.func
 }
 
 export default Select

--- a/src/stories/Select.stories.mdx
+++ b/src/stories/Select.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks'
 
 import { Select } from '../components'
-import { optionsSelect } from '../utils'
+import { customOptionsSelect, optionsSelect } from '../utils'
 import { ThemeProvider } from '../theme'
 
 <Meta title='Data input/Select' component={Select} argTypes={{ bg: { control: 'color' } }} />
@@ -14,7 +14,7 @@ export const SelectControls = args => (
 
 # Select
 
-O componente de `Select` é utilizado para que o usuário possa selecionar uma ou mais opções da aplicação.
+O componente de `Select` é utilizado para que o usuário possa selecionar uma ou mais opções da aplicação. A `ref` é encaminhada para o `Select`, assim como a prop `name`.
 
 <Story
   name='Base'
@@ -56,6 +56,99 @@ Passando a prop de `error` para o `Select`, o usuário pode receber um feedback 
   </Story>
 </Canvas>
 
+# Options
+
+O array `options` deve conter as `options` em formato de objeto. Por padrão o `Select` espera a label no campo `label` e o valor no campo `value`. Com a prop `optionLabel` podemos definir outro nome para o campo da label e com a prop `optionValue` podemos definir outro nome para o campo do value do Select no array de `options`.
+
+<Canvas>
+  <Story
+    name='Options'
+    parameters={{
+      design: {
+        type: 'figma',
+        url: 'https://www.figma.com/file/O3bKxIcsj2rc1FNIRclJyT/Saturn-System?node-id=242%3A139'
+      }
+    }}
+  >
+    <ThemeProvider>
+      <Select name='Options' options={customOptionsSelect} optionLabel='customLabel' optionValue='customValue' />
+    </ThemeProvider>
+  </Story>
+</Canvas>
+
+# Quiet
+
+A prop `quiet` remove as bordas do `Select`. Quando usando esta prop a `label` do `Select` não poderá ser usada, porém a `caption` poderá ser usada.
+
+<Canvas>
+  <Story
+    name='Quiet'
+    parameters={{
+      design: {
+        type: 'figma',
+        url: 'https://www.figma.com/file/O3bKxIcsj2rc1FNIRclJyT/Saturn-System?node-id=242%3A139'
+      }
+    }}
+  >
+    <ThemeProvider>
+      <Select name='Quiet' quiet options={optionsSelect} />
+      <Select name='QuietError' quiet error caption='quiet with error' options={optionsSelect} />
+    </ThemeProvider>
+  </Story>
+</Canvas>
+
+# On Option Selected
+
+O `Select` aceita a prop `onOptionSelected`. Uma função que recebe dois parâmetros, o primeiro sendo a `option` selecionado e o segundo `shouldValidate` que indica se o campo deve ser validado. Essa função é executada no momento em que uma `option` é escolhida.
+
+<Canvas>
+  <Story
+    name='OnOptionSelected'
+    parameters={{
+      design: {
+        type: 'figma',
+        url: 'https://www.figma.com/file/O3bKxIcsj2rc1FNIRclJyT/Saturn-System?node-id=242%3A139'
+      }
+    }}
+  >
+    <ThemeProvider>
+      <Select
+        name='OnOptionSelected'
+        label='onOptionSelected'
+        caption='onOptionSelected'
+        onOptionSelected={() => alert('onOptionSelected')}
+        options={optionsSelect}
+      />
+    </ThemeProvider>
+  </Story>
+</Canvas>
+
+# Reset Value
+
+O `Select` aceita a prop `resetValue` que é utilizada para mudar o valor do Select. Mas também pode ser utilizada para se ter o comportamento de `defaultValue`.
+
+<Canvas>
+  <Story
+    name='Reset Value'
+    parameters={{
+      design: {
+        type: 'figma',
+        url: 'https://www.figma.com/file/O3bKxIcsj2rc1FNIRclJyT/Saturn-System?node-id=242%3A139'
+      }
+    }}
+  >
+    <ThemeProvider>
+      <Select
+        name='ResetValue'
+        label='Reset Value'
+        caption='Reset Value'
+        resetValue={optionsSelect[0].value}
+        options={optionsSelect}
+      />
+    </ThemeProvider>
+  </Story>
+</Canvas>
+
 # Disabled
 
 O `Select` pode receber a prop de `disabled`, que desabilita todo o seu uso.
@@ -76,13 +169,14 @@ O `Select` pode receber a prop de `disabled`, que desabilita todo o seu uso.
   </Story>
 </Canvas>
 
-# Clear Value
+# Clear Value | onClearSelect
 
 Passando a prop `clearValue` para o `Select`, será exibido um icone no componente, ao tocar nesse icone o valor presente no `Select` será limpo.
+É possível passar a prop `onClearSelect`, que recebe uma função que será executada quando o `Select` for limpo.
 
 <Canvas>
   <Story
-    name='Clear Value'
+    name='Clear Value | onClearSelect'
     parameters={{
       design: {
         type: 'figma',
@@ -96,6 +190,14 @@ Passando a prop `clearValue` para o `Select`, será exibido um icone no componen
         name='clearValue'
         label='Clear Value'
         options={optionsSelect}
+        placeholder='Selecione uma opção'
+      />
+      <Select
+        clearValue
+        name='onClearSelect'
+        label='onClearSelect'
+        options={optionsSelect}
+        onClearSelect={() => alert('onClearSelect')}
         placeholder='Selecione uma opção'
       />
     </ThemeProvider>

--- a/src/stories/Select.stories.mdx
+++ b/src/stories/Select.stories.mdx
@@ -14,7 +14,7 @@ export const SelectControls = args => (
 
 # Select
 
-O componente de `Select` é utilizado para que o usuário possa selecionar uma ou mais opções da aplicação. A `ref` é encaminhada para o `Select`, assim como a prop `name`.
+O componente de `Select` é utilizado para que o usuário possa selecionar uma ou mais opções da aplicação. A `ref` é encaminhada para o `Select` HTML, assim como a prop `name`.
 
 <Story
   name='Base'

--- a/src/stories/Select.stories.mdx
+++ b/src/stories/Select.stories.mdx
@@ -97,13 +97,13 @@ A prop `quiet` remove as bordas do `Select`. Quando usando esta prop a `label` d
   </Story>
 </Canvas>
 
-# On Option Selected
+# onChange
 
-O `Select` aceita a prop `onOptionSelected`. Uma função que recebe dois parâmetros, o primeiro sendo a `option` selecionado e o segundo `shouldValidate` que indica se o campo deve ser validado. Essa função é executada no momento em que uma `option` é escolhida.
+O `Select` aceita a prop `onChange`. Uma função que recebe dois parâmetros, o primeiro sendo a `option` selecionado e o segundo `shouldValidate` que indica se o campo deve ser validado. Essa função é executada no momento em que uma `option` é escolhida.
 
 <Canvas>
   <Story
-    name='OnOptionSelected'
+    name='onChange'
     parameters={{
       design: {
         type: 'figma',
@@ -113,10 +113,10 @@ O `Select` aceita a prop `onOptionSelected`. Uma função que recebe dois parâm
   >
     <ThemeProvider>
       <Select
-        name='OnOptionSelected'
-        label='onOptionSelected'
-        caption='onOptionSelected'
-        onOptionSelected={() => alert('onOptionSelected')}
+        name='onChange'
+        label='onChange'
+        caption='onChange'
+        onChange={() => alert('onChange')}
         options={optionsSelect}
       />
     </ThemeProvider>
@@ -169,14 +169,14 @@ O `Select` pode receber a prop de `disabled`, que desabilita todo o seu uso.
   </Story>
 </Canvas>
 
-# Clear Value | onClearSelect
+# Clear Value | onClear
 
 Passando a prop `clearValue` para o `Select`, será exibido um icone no componente, ao tocar nesse icone o valor presente no `Select` será limpo.
-É possível passar a prop `onClearSelect`, que recebe uma função que será executada quando o `Select` for limpo.
+É possível passar a prop `onClear`, que recebe uma função que será executada quando o `Select` for limpo.
 
 <Canvas>
   <Story
-    name='Clear Value | onClearSelect'
+    name='Clear Value | onClear'
     parameters={{
       design: {
         type: 'figma',
@@ -194,10 +194,10 @@ Passando a prop `clearValue` para o `Select`, será exibido um icone no componen
       />
       <Select
         clearValue
-        name='onClearSelect'
-        label='onClearSelect'
+        name='onClear'
+        label='onClear'
         options={optionsSelect}
-        onClearSelect={() => alert('onClearSelect')}
+        onClear={() => alert('onClear')}
         placeholder='Selecione uma opção'
       />
     </ThemeProvider>

--- a/src/utils/optionsSelect/index.js
+++ b/src/utils/optionsSelect/index.js
@@ -1,1 +1,1 @@
-export { default as optionsSelect } from './optionsSelect'
+export * from './optionsSelect'

--- a/src/utils/optionsSelect/optionsSelect.js
+++ b/src/utils/optionsSelect/optionsSelect.js
@@ -1,4 +1,4 @@
-const optionsSelect = [
+export const optionsSelect = [
   {
     label: 'label 1',
     value: 'label_1'
@@ -33,4 +33,37 @@ const optionsSelect = [
   }
 ]
 
-export default optionsSelect
+export const customOptionsSelect = [
+  {
+    customLabel: 'label 1',
+    customValue: 'label_1'
+  },
+  {
+    customLabel: 'label 2',
+    customValue: 'label_2'
+  },
+  {
+    customLabel: 'label 3',
+    customValue: 'label_3'
+  },
+  {
+    customLabel: 'label 4',
+    customValue: 'label_4'
+  },
+  {
+    customLabel: 'label 5',
+    customValue: 'label_5'
+  },
+  {
+    customLabel: 'label 6',
+    customValue: 'label_6'
+  },
+  {
+    customLabel: 'label 7',
+    customValue: 'label_7'
+  },
+  {
+    customLabel: 'label 8',
+    customValue: 'label_8'
+  }
+]


### PR DESCRIPTION
**O que foi feito?**

1. Foi removido a prop `defaultValue` que não estava a funcionar. Podemos alcançar o mesmo objetivo através da prop `resetValue`. Coloquei isso na nova documentação proposta.
2. Foi alterado o segundo parâmetro do handleChange de `shouldValidation` para `shouldValidate`, corrigindo o sentido da frase.
3. Sugerido pelo @devSiso , agora passamos um `defaultValue` pro Select HTML,` defaultValue={optionSelected[optionValue]}` com objetivo semântico.
4. Foi adicionado um novo array de exemplo para o select, com nomes dos campos de label e value customizados.
5. Foi documentado a utilização das props de `optionLabel` e `optionValue`.
6. Foi documentado a utilização da prop `quiet`.
7. Foi documentado o uso da prop `onOptionSelected`, utilizei como exemplo um alert.
8. Foi documentado a utilização da prop `resetValue`.
9. Foi documentado a utilização da prop `onClearSelect`, também como exemplo eu utilizei um alert.

Documentei todas as props que podem ser utilizadas no Select, desde as mais simples até as mais complexas, para que a documentação esteja completa. Para que alguém consiga utilizar o componente sem ter de ir ler o código do componente.

**Duas Perguntas**
Essa nova documentação proposta contém todo o conteúdo que você gostaria que estivesse presente?

Fica a minha dúvida sobre o useEffect utilizado no componente, faz sentido substituir por outro hook do React?