### PR TITLE
refactor: replaced @xstyled for styled-components and styled-system

### DIFF
--- a/src/components/Tag/Tag.jsx
+++ b/src/components/Tag/Tag.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled, { css } from 'styled-components'
-import {variant, compose, color, layout, space, border } from 'styled-system'
+import { variant, compose, color, layout, space, border } from 'styled-system'
 import PropTypes from 'prop-types'
 import { Typography } from '../'
 import { Icon } from '../Iconography'
@@ -18,59 +18,63 @@ const Tag = ({ children, close, ...props }) => (
 
 const baseProps = compose(color, layout, space, border)
 
-const selectedVariant = ({theme: {colors}, color}) => variant({
-  default: true,
-  prop: 'selected',
-  key: 'tag',
-  variants: {
-    true: {
-      backgroundColor: colors[color],
-      borderColor: colors[color],
-      cursor: 'pointer',
-      p: {
-        color: 'white'
-      }
-    },
-    false: {
-      backgroundColor: 'transparent',
-      borderColor: colors.gray['600'],
-      cursor: 'pointer',
-      p: {
-        color: colors.gray['600']
-      }
-    },
-    disabled: {
-      backgroundColor: 'disabled',
-      borderColor: 'disabled',
-      cursor: 'default',
-      p: {
-        color: 'white'
+const selectedVariant = ({ theme: { colors }, color }) =>
+  variant({
+    default: true,
+    prop: 'selected',
+    key: 'tag',
+    variants: {
+      true: {
+        backgroundColor: colors[color],
+        borderColor: colors[color],
+        cursor: 'pointer',
+        p: {
+          color: 'white'
+        }
+      },
+      false: {
+        backgroundColor: 'transparent',
+        borderColor: colors.gray['600'],
+        cursor: 'pointer',
+        p: {
+          color: colors.gray['600']
+        }
+      },
+      disabled: {
+        backgroundColor: 'disabled',
+        borderColor: 'disabled',
+        cursor: 'default',
+        p: {
+          color: 'white'
+        }
       }
     }
-  }
-})
+  })
 
 const Base = styled.div(
   props => css`
-  display: inline-block;
-  border-radius: 1;
-  border-width: 1px;
-  border-style: solid;
-  ${border}
-  ${baseProps}
+    display: inline-block;
+    border-radius: ${props.theme.space[1]}px;
+    border-width: 1px;
+    border-style: solid;
+    ${border}
+    ${baseProps}
   ${selectedVariant(props)}
-`)
+  `
+)
 
 const Content = styled.div`
   display: flex;
   align-items: center;
 `
 
-const Text = styled(Typography)`
-  font-weight: 600;
-  font-size: 12px;
-  line-height: 16px;
-`
+const Text = styled(Typography)(
+  ({ theme: { fontWeights, lineHeights, fontSizes } }) => css`
+    font-weight: ${fontWeights[1]};
+    font-size: ${fontSizes[1]}px;
+    line-height: ${lineHeights[1]};
+  `
+)
 
 Tag.defaultProps = {
   selected: true,

--- a/src/components/Tag/Tag.jsx
+++ b/src/components/Tag/Tag.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
-import styled, { css } from '@xstyled/styled-components'
-import { th, variant, compose, color, layout, space, border } from '@xstyled/system'
+import styled, { css } from 'styled-components'
+import {variant, compose, color, layout, space, border } from 'styled-system'
 import PropTypes from 'prop-types'
 import { Typography } from '../'
 import { Icon } from '../Iconography'
@@ -18,46 +18,48 @@ const Tag = ({ children, close, ...props }) => (
 
 const baseProps = compose(color, layout, space, border)
 
-const selectedVariant = variant({
+const selectedVariant = ({theme: {colors}, color}) => variant({
   default: true,
   prop: 'selected',
   key: 'tag',
   variants: {
-    true: css`
-      background-color: ${({ color }) => th.color(color)};
-      border-color: ${({ color }) => th.color(color)};
-      cursor: pointer;
-      p {
-        color: white;
+    true: {
+      backgroundColor: colors[color],
+      borderColor: colors[color],
+      cursor: 'pointer',
+      p: {
+        color: 'white'
       }
-    `,
-    false: css`
-      background-color: transparent;
-      border-color: gray.600;
-      cursor: pointer;
-      p {
-        color: gray.600;
+    },
+    false: {
+      backgroundColor: 'transparent',
+      borderColor: colors.gray['600'],
+      cursor: 'pointer',
+      p: {
+        color: colors.gray['600']
       }
-    `,
-    disabled: css`
-      background-color: disabled;
-      border-color: disabled;
-      cursor: default;
-      p {
-        color: white;
+    },
+    disabled: {
+      backgroundColor: 'disabled',
+      borderColor: 'disabled',
+      cursor: 'default',
+      p: {
+        color: 'white'
       }
-    `
+    }
   }
 })
 
-const Base = styled.div`
+const Base = styled.div(
+  props => css`
   display: inline-block;
   border-radius: 1;
   border-width: 1px;
   border-style: solid;
+  ${border}
   ${baseProps}
-  ${selectedVariant}
-`
+  ${selectedVariant(props)}
+`)
 
 const Content = styled.div`
   display: flex;
@@ -65,9 +67,9 @@ const Content = styled.div`
 `
 
 const Text = styled(Typography)`
-  font-weight: 1;
-  font-size: 1;
-  line-height: 1;
+  font-weight: 600;
+  font-size: 12px;
+  line-height: 16px;
 `
 
 Tag.defaultProps = {

--- a/src/utils/color/index.jsx
+++ b/src/utils/color/index.jsx
@@ -3,7 +3,7 @@ export const getThemeColor = (colorName, theme) => {
   const colorOnTheme = theme.colors[color]
 
   if (colorOnTheme) {
-    const colorWithHue = theme.colors[color][`${hue}`] || theme.colors[color]['500']
+    const colorWithHue = theme.colors[color][`${hue}`] || theme.colors[color]
     return colorWithHue
   }
 


### PR DESCRIPTION
## What does this MR do?
- replace @xstyled for styled-components and styled-system;
- adds a border radius prop.

## Related cards and external links
- [here](https://naveteam.atlassian.net/secure/RapidBoard.jspa?rapidView=110&projectKey=DSYS&modal=detail&selectedIssue=DSYS-420&assignee=60a281ac5998a60068494d5b)

## Put here related images if exists

## Checklist

- [x] Fullfil What does this MR do?
- [x] [Follow vnt git guides](https://grupo-vnt.gitlab.io/guides/nave/git/)
- [x] [Squash pull request into a single commit](http://eli.thegreenplace.net/2014/02/19/squashing-github-pull-requests-into-a-single-commit/)
- [ ] Your team's review (required)